### PR TITLE
Remoção Deeplink PagBank

### DIFF
--- a/easylistportuguese/easylistportuguese_specific_hide.txt
+++ b/easylistportuguese/easylistportuguese_specific_hide.txt
@@ -310,7 +310,6 @@ cointimes.com.br##[href^="https://cointimes.com.br/linkout/"]
 cointimes.com.br##.adv-link
 cointimes.com.br###media_image-13
 revistaencontro.com.br##small.txt-no-serif
-uol.com.br##[href^="https://pagbank.onelink.me/"]
 igg-games.com##[href^="http://s.igg-games.com/index.php?"]
 buceteiro.com#?#li:-abp-has(#thumb-6110)
 buceteiro.com###related


### PR DESCRIPTION
A linha uol.com.br##[href^="https://pagbank.onelink.me/"] bloqueia os deeplinks do PagBank, aplicativo do PagSeguro. Desta forma o usuário não é direcionado para o aplicativo ou fallback, não podendo completar a ação desejada.